### PR TITLE
Add parts for exo_dolg_red_outfit

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Armors no integrated helmet/gamedata/configs/items/settings/mod_parts_g_a_m_m_a_no_integrated_helmets_in_armors.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Armors no integrated helmet/gamedata/configs/items/settings/mod_parts_g_a_m_m_a_no_integrated_helmets_in_armors.ltx
@@ -56,6 +56,7 @@ exo_merc_grass_outfit = prt_o_fabrics_4,		prt_o_retardant_5,		prt_o_ballistic_11
 exo_merc_urban_outfit = prt_o_fabrics_4,		prt_o_retardant_6,		prt_o_ballistic_1,		prt_o_ballistic_17,		prt_o_ballistic_5
 exo_merc_wood_outfit = prt_o_fabrics_3,		prt_o_retardant_7,		prt_o_ballistic_5,		prt_o_ballistic_20,		prt_o_ballistic_11
 exo_dolg_outfit = prt_o_fabrics_4,		prt_o_retardant_19,		prt_o_ballistic_6,		prt_o_ballistic_12,		prt_o_ballistic_5
+exo_dolg_red_outfit =	prt_o_fabrics_4,		prt_o_retardant_13,		prt_o_ballistic_2,		prt_o_ballistic_20,		prt_o_ballistic_5
 exo_dolg_wood_outfit = prt_o_fabrics_3,		prt_o_retardant_5,		prt_o_ballistic_9,		prt_o_ballistic_20,		prt_o_ballistic_5
 exo_dolg_urban_outfit = prt_o_fabrics_4,		prt_o_retardant_6,		prt_o_ballistic_1,		prt_o_ballistic_17,		prt_o_ballistic_5
 freedom_exo_vineleaf_outfit = prt_o_fabrics_4,		prt_o_retardant_9,		prt_o_ballistic_2,		prt_o_ballistic_7,		prt_o_ballistic_5


### PR DESCRIPTION
Parts chosen based on outfit stats relative to other Duty exolights (better burn res). Allows this outfit to be repaired.